### PR TITLE
autocomplete

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,12 +28,12 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: wat3.db.zst
-          key: wat3.db.zst
-          restore-keys: wat3.db.zst
+          path: wat4.db.zst
+          key: wat4.db.zst
+          restore-keys: wat4.db.zst
 
-      - run: curl -C - -O https://hexdocs-artifacts.s3.eu-central-003.backblazeb2.com/wat3.db.zst
-      - run: zstd --rm wat3.db.zst -o wat3.db -d
+      - run: curl -C - -O https://hexdocs-artifacts.s3.eu-central-003.backblazeb2.com/wat4.db.zst
+      - run: zstd --rm wat4.db.zst -o wat4.db -d
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,12 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: wat3.db.zst
-          key: wat3.db.zst
-          restore-keys: wat3.db.zst
+          path: wat4.db.zst
+          key: wat4.db.zst
+          restore-keys: wat4.db.zst
 
-      - run: curl -C - -O https://hexdocs-artifacts.s3.eu-central-003.backblazeb2.com/wat3.db.zst
-      - run: zstd --rm wat3.db.zst -o wat3.db -d
+      - run: curl -C - -O https://hexdocs-artifacts.s3.eu-central-003.backblazeb2.com/wat4.db.zst
+      - run: zstd --rm wat4.db.zst -o wat4.db -d
 
       - uses: actions/cache@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN mix release
 FROM alpine:3.18.2 AS artifacts
 RUN apk add curl zstd
 WORKDIR /export
-RUN curl -O https://hexdocs-artifacts.s3.eu-central-003.backblazeb2.com/wat3.db.zst
-RUN zstd --rm wat3.db.zst -o wat.db -d
+RUN curl -O https://hexdocs-artifacts.s3.eu-central-003.backblazeb2.com/wat4.db.zst
+RUN zstd --rm wat4.db.zst -o wat.db -d
 
 # start a new build stage so that the final image will only contain
 # the compiled release and other runtime necessities

--- a/bench/search.exs
+++ b/bench/search.exs
@@ -20,5 +20,6 @@ repos = ["ecto", "ecto_sql", "phoenix", "phoenix_live_view"]
 random_repos = fn -> Enum.take_random(repos, :rand.uniform(5)) end
 
 Benchee.run(%{
-  "api_fts/2" => fn -> Wat.api_fts(random_query.(), random_repos.()) end
+  "api_fts/2" => fn -> Wat.api_fts(random_query.(), random_repos.()) end,
+  "api_autocomplete/2" => fn -> Wat.api_autocomplete(random_query.(), random_repos.()) end
 })

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,7 +20,7 @@ import Config
 default_db =
   case config_env() do
     :prod -> "/app/wat.db"
-    _env -> Path.expand("../wat3.db", Path.dirname(__ENV__.file))
+    _env -> Path.expand("../wat4.db", Path.dirname(__ENV__.file))
   end
 
 config :wat,

--- a/lib/wat.ex
+++ b/lib/wat.ex
@@ -13,6 +13,7 @@ defmodule Wat do
     {:ok, db} = Sqlite3.open(database, mode: :readonly)
     # :ets.new(:hexdocs_stmt_cache)
     :ok = Sqlite3.execute(db, "pragma cache_size=-64000")
+    :ok = Sqlite3.execute(db, "pragma temp_store=memory")
     :ok = Sqlite3.enable_load_extension(db, true)
     ext_path = :filename.join(:code.priv_dir(:wat), ~c"hexdocs.so")
     {:ok, _} = query(db, "select load_extension(?)", [ext_path])
@@ -48,9 +49,8 @@ defmodule Wat do
           table = "hexdocs_" <> package <> "_fts"
 
           sql = """
-          select d.ref, d.type, f.title, snippet(#{table}, 1, '<em>', '</em>', '...', 20), hexdocs_rank(#{table}) \
+          select f.ref, f.type, f.title, snippet(#{table}, 1, '<em>', '</em>', '...', 20), hexdocs_rank(#{table}) \
           from #{table} f \
-          inner join docs d on f.rowid = d.id \
           where #{table} match ? \
           order by 5 desc \
           limit 25\
@@ -193,10 +193,10 @@ defmodule Wat do
       |> Task.Supervisor.async_stream_nolink(
         packages,
         fn package ->
-          table = "hexdocs_" <> package <> "_fts"
+          table = "hexdocs_" <> package <> "_autocomplete"
 
           sql = """
-          select f.title \
+          select f.title, f.ref, f.type \
           from #{table} f \
           where title match ? \
           limit 3\
@@ -205,8 +205,8 @@ defmodule Wat do
           {:ok, rows} = query(db, sql, [query])
 
           Enum.map(rows, fn row ->
-            [title] = row
-            %{title: title, package: package}
+            [title, ref, type] = row
+            %{title: title, ref: ref, type: type, package: package}
           end)
         end,
         # ordered: false,

--- a/lib/wat/router.ex
+++ b/lib/wat/router.ex
@@ -9,6 +9,7 @@ defmodule Wat.Router do
   plug :dispatch
 
   get "/v0/search", do: search(conn)
+  get "/v0/autocomplete", do: autocomplete(conn)
 
   match _ do
     send_resp(conn, 404, "Not found")
@@ -16,18 +17,25 @@ defmodule Wat.Router do
 
   def search(%{query_params: query_params} = conn) do
     query = query_params["q"]
-
-    packages =
-      case query_params["packages"] do
-        packages when is_list(packages) -> packages
-        packages when is_binary(packages) -> String.split(packages, ",")
-        nil -> []
-      end
-
+    packages = packages(query_params["packages"])
     results = Wat.api_fts(query, packages)
 
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(200, Jason.encode_to_iodata!(%{"results" => results}))
   end
+
+  def autocomplete(%{query_params: query_params} = conn) do
+    query = query_params["q"]
+    packages = packages(query_params["packages"])
+    results = Wat.api_autocomplete(query, packages)
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Jason.encode_to_iodata!(%{"results" => results}))
+  end
+
+  defp packages(packages) when is_list(packages), do: packages
+  defp packages(packages) when is_binary(packages), do: String.split(packages, ",")
+  defp packages(nil), do: []
 end

--- a/test/wat/wat_test.exs
+++ b/test/wat/wat_test.exs
@@ -153,6 +153,30 @@ defmodule WatTest do
     end
   end
 
+  describe "api_autocomplete/2" do
+    test "empty query" do
+      assert Wat.api_autocomplete("", ["ecto"]) == []
+    end
+
+    test "empty packages" do
+      assert Wat.api_autocomplete("query", []) == []
+    end
+
+    test "query" do
+      assert take_titles(Wat.api_autocomplete("query", ["ecto", "ecto_sql", "plug"])) == [
+               "Query - Ecto",
+               "Ecto.Query",
+               "Query expressions - Ecto.Query",
+               "Ecto.Adapters.SQL.query/4",
+               "Ecto.Adapters.SQL.query!/4",
+               "Ecto.Adapters.SQL.query_many/4",
+               "Plug.Conn.fetch_query_params/2",
+               "Plug.Conn.query_param/0",
+               "Plug.Conn.query_params/0"
+             ]
+    end
+  end
+
   defp take_titles(docs, count \\ 10) do
     docs |> Enum.map(& &1.title) |> Enum.take(count)
   end


### PR DESCRIPTION
This PR adds autocomplete support to be used in addition to local autocomplete. Right now I think we can use a racing promise and drop the remote autocomplete request if it takes more than 100ms to return. Another idea is to run remote autocomplete on some additional action, like hitting `<tab>`